### PR TITLE
Avoid namespace clashes between library and executable lldb, add helpful debug logs to CMakeLists

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,12 +32,17 @@ add_executable(${CMAKE_PROJECT_NAME}
 )
 
 find_path(LLVM_INCLUDE_DIR
-    NAMES lldb
+    NAMES libunwind.h
     PATHS
         /usr/local/opt/llvm/include
         /opt/homebrew/opt/llvm/include
+        NO_DEFAULT_PATH
         # TODO(Apaar): Add windows search paths
 )
+
+if(NOT LLVM_INCLUDE_DIR)
+    message(FATAL_ERROR "LLVM include directory not found.")
+endif()
 
 # Find LLDB library
 find_library(LLDB_LIBRARY
@@ -47,6 +52,13 @@ find_library(LLDB_LIBRARY
         /opt/homebrew/opt/llvm/lib
         # TODO(Apaar): Add windows paths
 )
+
+if(NOT LLDB_LIBRARY)
+    message(FATAL_ERROR "LLDB library not found.")
+endif()
+
+message(STATUS "LLVM Include Directory: ${LLVM_INCLUDE_DIR}")
+message(STATUS "LLDB Library: ${LLDB_LIBRARY}")
 
 target_compile_options(${CMAKE_PROJECT_NAME} PRIVATE -Wall -Wextra -Wpedantic)
 


### PR DESCRIPTION
On my machine, lodeb was not building because `find_path` was picking up `lldb` the executable in `/usr/bin`, not `lldb` the library. The error was manifesting as many lines of `error: source file is not valid UTF-8` on build. By searching for the path of `libunwind.h` instead which is in the same directory as the `lldb` library, the probability of namespace collision falls to almost 0.

I have cmake version 3.28.3, and it seems like the build worked by default on a later version of cmake. Something to do with cmake's default path searching behaviour?

Also I had to delete the `build` dir and/or `cmake --build build --parallel --target clean` before the change was picked up.

Thanks @goodpaul6 for debugging the debugger with me!